### PR TITLE
Add HF model option

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,11 +16,20 @@ def main():
     parser.add_argument("--evaluate", action="store_true", help="Run evaluation")
     parser.add_argument("--interactive", action="store_true", help="Run interactive mode")
     parser.add_argument("--question", type=str, help="Ask a specific question")
+    parser.add_argument("--llama", action="store_true", help="Use Llama 2 model via HuggingFace")
+    parser.add_argument("--phi", action="store_true", help="Use Phi-2 model via HuggingFace")
     
     args = parser.parse_args()
-    
+
+    # Determine which LLM to use
+    llm_type = "openai"
+    if args.phi:
+        llm_type = "phi"
+    elif args.llama:
+        llm_type = "llama"
+
     # Initialize QA system
-    qa_system = QASystem()
+    qa_system = QASystem(llm_type=llm_type)
     
     if args.build:
         print("Building knowledge base...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ python-dotenv
 streamlit
 ragas
 datasets
-flask
-pyyaml
+flaskpyyaml
+transformers

--- a/src/hf_llm.py
+++ b/src/hf_llm.py
@@ -1,0 +1,49 @@
+"""HuggingFace LLM integration for Phi-2 and Llama models"""
+from typing import List
+from dataclasses import dataclass
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+from src.llm_pipeline import QAResponse
+
+
+@dataclass
+class HFConfig:
+    model_name: str = "microsoft/phi-2"
+    device: str = "cpu"
+    max_new_tokens: int = 512
+    temperature: float = 0.2
+
+
+class HFLLM:
+    """Simple wrapper around HuggingFace text-generation pipeline"""
+
+    def __init__(self, config: HFConfig = HFConfig()):
+        self.config = config
+        self.tokenizer = AutoTokenizer.from_pretrained(config.model_name)
+        self.model = AutoModelForCausalLM.from_pretrained(config.model_name)
+        device_index = 0 if config.device == "cuda" else -1
+        self.generator = pipeline(
+            "text-generation",
+            model=self.model,
+            tokenizer=self.tokenizer,
+            device=device_index,
+        )
+
+    def generate_answer(self, question: str, context: List[str]) -> QAResponse:
+        context_text = "\n\n".join(context)
+        prompt = f"{context_text}\n\nQuestion: {question}\nAnswer:"
+        outputs = self.generator(
+            prompt,
+            max_new_tokens=self.config.max_new_tokens,
+            temperature=self.config.temperature,
+            num_return_sequences=1,
+        )
+        generated = outputs[0]["generated_text"]
+        answer = generated.split("Answer:", 1)[-1].strip()
+        return QAResponse(
+            answer=answer,
+            context=context,
+            confidence=0.6,
+            sources=[f"Context {i+1}" for i in range(len(context))],
+        )
+

--- a/src/question_answering.py
+++ b/src/question_answering.py
@@ -7,17 +7,19 @@ from src.data_loader import GutenbergLoader, TextProcessor
 from src.embeddings import HuggingFaceEmbeddings
 from src.vector_store import FAISSVectorStore
 from src.llm_pipeline import OpenAILLM, QAResponse
+from src.hf_llm import HFLLM, HFConfig
 
 import os
 
 class QASystem:
     """Main Question Answering System"""
-    
-    def __init__(self, config_path: str = "config/config.yaml"):
+
+    def __init__(self, config_path: str = "config/config.yaml", llm_type: str = "openai"):
         self.config = self._load_config(config_path)
         self.embeddings = None
         self.vector_store = None
         self.llm = None
+        self.llm_type = llm_type
         self._setup_components()
     
     def _load_config(self, config_path: str) -> Dict[str, Any]:
@@ -37,11 +39,26 @@ class QASystem:
         self.vector_store = FAISSVectorStore(self.embeddings)
         
         # Setup LLM
-        self.llm = OpenAILLM(
-            model_name=self.config['llm']['model_name'],
-            temperature=self.config['llm']['temperature'],
-            max_tokens=self.config['llm']['max_tokens']
-        )
+        if self.llm_type == "phi":
+            self.llm = HFLLM(
+                HFConfig(
+                    model_name="microsoft/phi-2",
+                    device=self.config['embeddings']['device'],
+                )
+            )
+        elif self.llm_type == "llama":
+            self.llm = HFLLM(
+                HFConfig(
+                    model_name="meta-llama/Llama-2-7b-chat-hf",
+                    device=self.config['embeddings']['device'],
+                )
+            )
+        else:
+            self.llm = OpenAILLM(
+                model_name=self.config['llm']['model_name'],
+                temperature=self.config['llm']['temperature'],
+                max_tokens=self.config['llm']['max_tokens']
+            )
     
     def build_knowledge_base(self):
         """Build the knowledge base from Gutenberg text"""


### PR DESCRIPTION
## Summary
- support HuggingFace text generation models
- allow selecting `--llama` or `--phi` in `main.py`
- instantiate new models in question answering module
- include `transformers` in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: SystemExit because no API key)*

------
https://chatgpt.com/codex/tasks/task_e_686d6d7d95188328b9db9e5733b8a895